### PR TITLE
feat: GlobalExceptionHandler 구현 및 Controller 예외 처리 리팩토링

### DIFF
--- a/src/main/java/com/url/ShortenIt/domain/url/controller/UrlController.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/controller/UrlController.java
@@ -30,39 +30,27 @@ public class UrlController {
     @PostMapping("/shorten")
     @Operation(summary = "URL 단축", description = "URL을 단축합니다.")
     public ApiResponse<?> createShortUrl(@RequestBody LongUrlRequest request) {
-        try {
-            String longUrl = request.getLongUrl();
-            if (longUrl == null || longUrl.isBlank()) {
-                return ApiResponseGenerator.fail("invalid_request", "long_url 값이 비어 있습니다.", HttpStatus.BAD_REQUEST);
-            }
-            String shortUrl = urlService.saveShortUrl(longUrl);
-            return ApiResponseGenerator.success(shortUrl, HttpStatus.OK, MessageCode.SUCCESS);
-        } catch (Exception e) {
-            return ApiResponseGenerator.fail("error", e.getMessage(), HttpStatus.BAD_REQUEST);
+        String longUrl = request.getLongUrl();
+        if (longUrl == null || longUrl.isBlank()) {
+            throw new IllegalArgumentException("long_url 값이 비어 있습니다.");
         }
+        String shortUrl = urlService.saveShortUrl(longUrl);
+        return ApiResponseGenerator.success(shortUrl, HttpStatus.OK, MessageCode.SUCCESS);
     }
 
     @GetMapping("/{shortUrl}")
     @Operation(summary = "URL 리다이렉트", description = "단축된 URL을 리다이렉트합니다.")
     public ResponseEntity<Void> redirectToLongUrl(@Parameter(description = "단축된 URL", example = "abc123") @PathVariable String shortUrl) {
-        try {
-            Url url = urlService.searchLongUrl(shortUrl);
-            return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY)
-                    .location(URI.create(url.getLongUrl()))
-                    .build();
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-        }
+        Url url = urlService.searchLongUrl(shortUrl);
+        return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY)
+                .location(URI.create(url.getLongUrl()))
+                .build();
     }
 
     @GetMapping("/{shortUrl}/preview")
     @Operation(summary = "URL 미리보기", description = "리다이렉트 대신 원본 URL을 JSON으로 반환합니다.")
     public ApiResponse<?> preview(@Parameter(description = "단축된 URL", example = "abc123") @PathVariable String shortUrl) {
-        try {
-            Url url = urlService.searchLongUrl(shortUrl);
-            return ApiResponseGenerator.success(url.getLongUrl(), HttpStatus.OK, MessageCode.SUCCESS);
-        } catch (Exception e) {
-            return ApiResponseGenerator.fail("not_found", e.getMessage(), HttpStatus.NOT_FOUND);
-        }
+        Url url = urlService.searchLongUrl(shortUrl);
+        return ApiResponseGenerator.success(url.getLongUrl(), HttpStatus.OK, MessageCode.SUCCESS);
     }
 }

--- a/src/main/java/com/url/ShortenIt/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/url/ShortenIt/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.url.ShortenIt.global.exception;
+
+import com.url.ShortenIt.domain.support.ApiResponse;
+import com.url.ShortenIt.domain.support.ApiResponseGenerator;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<ApiResponse.FailureBody>> handleIllegalArgumentException(IllegalArgumentException ex) {
+        return new ResponseEntity<>(
+                ApiResponseGenerator.fail("invalid_request", ex.getMessage(), HttpStatus.BAD_REQUEST),
+                HttpStatus.BAD_REQUEST
+        );
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<ApiResponse.FailureBody>> handleException(Exception ex) {
+        return new ResponseEntity<>(
+                ApiResponseGenerator.fail("internal_error", ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR),
+                HttpStatus.INTERNAL_SERVER_ERROR
+        );
+    }
+}
+


### PR DESCRIPTION
- GlobalExceptionHandler 클래스 생성 
  - IllegalArgumentException
  - Exception 처리
  - @RestControllerAdvice로 전역 예외 처리
- UrlController의 try-catch 제거하고 예외를 던지도록 수정
   - 모든 메서드에서 try-catch 제거
   - 예외는 GlobalExceptionHandler에서 처리하도록 변경
   - 코드 간소화

- 프로젝트 규칙 준수: 예외 처리를 GlobalExceptionHandler로 위임
