### PR TITLE
feat: URL 삭제 API 구현 및 Redis 캐시 삭제 로직 추가

### DIFF
--- a/src/main/java/com/url/ShortenIt/domain/url/controller/UrlController.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/controller/UrlController.java
@@ -51,4 +51,11 @@ public class UrlController {
         UrlInfoResponse urlInfo = urlService.searchLongUrl(shortUrl);
         return ResponseEntity.ok(urlInfo);
     }
+
+    @DeleteMapping("/{shortUrl}")
+    @Operation(summary = "URL 삭제", description = "단축된 URL을 삭제합니다.")
+    public ResponseEntity<Void> deleteUrl(@Parameter(description = "단축된 URL", example = "abc123") @PathVariable String shortUrl) {
+        urlService.deleteUrl(shortUrl);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/url/ShortenIt/domain/url/service/UrlService.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/service/UrlService.java
@@ -8,5 +8,5 @@ public interface UrlService {
 
     ShortUrlResponse saveShortUrl(String longUrl);
     UrlInfoResponse searchLongUrl(String shortUrl);
-
+    void deleteUrl(String shortUrl);
 }

--- a/src/main/java/com/url/ShortenIt/domain/url/service/UrlServiceIpml.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/service/UrlServiceIpml.java
@@ -83,6 +83,17 @@ public class UrlServiceIpml implements UrlService {
         return new UrlInfoResponse(found.getLongUrl(), found.getShortUrl());
     }
 
+    @Override
+    @Transactional
+    public void deleteUrl(String shortUrl) {
+        Url url = Urlrepository.findByShortUrl(shortUrl).orElseThrow(() -> new IllegalArgumentException("Short URL not found: " + shortUrl));
+        String longUrl = url.getLongUrl();
+        Urlrepository.delete(url);
+        // Redis 캐시 삭제
+        deleteFromCache(CACHE_S2L_PREFIX + shortUrl);
+        deleteFromCache(CACHE_L2S_PREFIX + longUrl);
+    }
+
     private String normalizeLongUrl(String original) {
         if (original == null) {
             throw new IllegalArgumentException("long_url must not be null");
@@ -115,6 +126,14 @@ public class UrlServiceIpml implements UrlService {
         if (redisTemplate == null) return;
         try {
             redisTemplate.opsForValue().set(key, value, Duration.ofHours(24));
+        } catch (Exception ignored) {
+        }
+    }
+
+    private void deleteFromCache(String key) {
+        if (redisTemplate == null) return;
+        try {
+            redisTemplate.delete(key);
         } catch (Exception ignored) {
         }
     }


### PR DESCRIPTION
- UrlController에 DELETE /api/v1/url/{shortUrl} 엔드포인트 추가
- UrlService에 deleteUrl 메서드 추가
- UrlServiceIpml에 deleteUrl 구현 및 Redis 캐시 삭제 로직 추가
- 삭제 시 S2L, L2S 캐시 모두 삭제하도록 구현