### PR TITLE
feat: Redis Pub/Sub 기반 캐시 무효화 아키텍처 도입

### DIFF
--- a/src/main/java/com/url/ShortenIt/domain/url/service/CacheInvalidationPublisher.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/service/CacheInvalidationPublisher.java
@@ -1,0 +1,23 @@
+package com.url.ShortenIt.domain.url.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CacheInvalidationPublisher {
+
+    private static final String CACHE_INVALIDATION_TOPIC = "cache:invalidation";
+
+    @Autowired(required = false)
+    private StringRedisTemplate redisTemplate;
+
+    public void publishInvalidation(String shortUrl, String longUrl) {
+        if (redisTemplate == null) return;
+        try {
+            String message = shortUrl + "|" + longUrl;
+            redisTemplate.convertAndSend(CACHE_INVALIDATION_TOPIC, message);
+        } catch (Exception ignored) {
+        }
+    }
+}

--- a/src/main/java/com/url/ShortenIt/domain/url/service/CacheInvalidationSubscriber.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/service/CacheInvalidationSubscriber.java
@@ -1,0 +1,36 @@
+package com.url.ShortenIt.domain.url.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CacheInvalidationSubscriber {
+
+    private static final String CACHE_L2S_PREFIX = "L2S:";
+    private static final String CACHE_S2L_PREFIX = "S2L:";
+
+    @Autowired(required = false)
+    private StringRedisTemplate redisTemplate;
+
+    public void onMessage(String message, String channel) {
+        if (redisTemplate == null) return;
+        try {
+            String[] parts = message.split("\\|", 2);
+            if (parts.length != 2) {
+                log.warn("Invalid cache invalidation message: {}", message);
+                return;
+            }
+            String shortUrl = parts[0];
+            String longUrl = parts[1];
+
+            redisTemplate.delete(CACHE_S2L_PREFIX + shortUrl);
+            redisTemplate.delete(CACHE_L2S_PREFIX + longUrl);
+            log.info("Cache invalidated for shortUrl={}, longUrl={}", shortUrl, longUrl);
+        } catch (Exception e) {
+            log.error("Failed to process cache invalidation message", e);
+        }
+    }
+}

--- a/src/main/java/com/url/ShortenIt/domain/url/service/UrlServiceIpml.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/service/UrlServiceIpml.java
@@ -23,7 +23,8 @@ public class UrlServiceIpml implements UrlService {
 
     private final Urlrepository Urlrepository;
     private final BaseConversion BaseConversion;
-    
+    private final CacheInvalidationPublisher cacheInvalidationPublisher;
+
     @Autowired(required = false)
     private StringRedisTemplate redisTemplate;
 
@@ -89,9 +90,8 @@ public class UrlServiceIpml implements UrlService {
         Url url = Urlrepository.findByShortUrl(shortUrl).orElseThrow(() -> new IllegalArgumentException("Short URL not found: " + shortUrl));
         String longUrl = url.getLongUrl();
         Urlrepository.delete(url);
-        // Redis 캐시 삭제
-        deleteFromCache(CACHE_S2L_PREFIX + shortUrl);
-        deleteFromCache(CACHE_L2S_PREFIX + longUrl);
+        // Redis Pub/Sub을 통한 캐시 무효화 (모든 인스턴스에 전파)
+        cacheInvalidationPublisher.publishInvalidation(shortUrl, longUrl);
     }
 
     private String normalizeLongUrl(String original) {

--- a/src/main/java/com/url/ShortenIt/global/config/RedisPubSubConfig.java
+++ b/src/main/java/com/url/ShortenIt/global/config/RedisPubSubConfig.java
@@ -1,0 +1,39 @@
+package com.url.ShortenIt.global.config;
+
+import com.url.ShortenIt.domain.url.service.CacheInvalidationSubscriber;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+
+@Configuration
+@ConditionalOnBean(RedisConnectionFactory.class)
+public class RedisPubSubConfig {
+
+    public static final String CACHE_INVALIDATION_TOPIC = "cache:invalidation";
+
+    @Bean
+    public ChannelTopic cacheInvalidationTopic() {
+        return new ChannelTopic(CACHE_INVALIDATION_TOPIC);
+    }
+
+    @Bean
+    public MessageListenerAdapter messageListenerAdapter(CacheInvalidationSubscriber subscriber) {
+        return new MessageListenerAdapter(subscriber, "onMessage");
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            MessageListenerAdapter messageListenerAdapter,
+            ChannelTopic cacheInvalidationTopic) {
+
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(messageListenerAdapter, cacheInvalidationTopic);
+        return container;
+    }
+}


### PR DESCRIPTION
## Summary
- Redis Pub/Sub 설정 클래스 구현 (`RedisMessageListenerContainer`, `ChannelTopic`)
- 캐시 무효화 메시지 Publisher/Subscriber 구현
- URL 삭제 시 모든 인스턴스에 캐시 무효화 메시지 전파

## 변경 사항
- `RedisPubSubConfig`: Redis Pub/Sub 인프라 설정
- `CacheInvalidationPublisher`: `cache:invalidation` 토픽으로 메시지 발행
- `CacheInvalidationSubscriber`: 메시지 수신 후 해당 키의 Redis 캐시 삭제
- `UrlServiceIpml`: 기존 직접 캐시 삭제 → Pub/Sub 기반 캐시 무효화로 변경

## Test plan
- [x] `./gradlew build` 성공
- [ ] Docker 환경에서 다중 인스턴스 배포 후 캐시 무효화 전파 확인

Closes #25