### PR TITLE
feat: Spring Scheduler 기반 만료 데이터 배치 삭제

### DIFF
--- a/src/main/java/com/url/ShortenIt/ShortlyApplication.java
+++ b/src/main/java/com/url/ShortenIt/ShortlyApplication.java
@@ -2,7 +2,9 @@ package com.url.ShortenIt;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class ShortlyApplication {
 

--- a/src/main/java/com/url/ShortenIt/domain/url/controller/UrlController.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/controller/UrlController.java
@@ -32,7 +32,7 @@ public class UrlController {
         if (longUrl == null || longUrl.isBlank()) {
             throw new IllegalArgumentException("long_url 값이 비어 있습니다.");
         }
-        ShortUrlResponse response = urlService.saveShortUrl(longUrl);
+        ShortUrlResponse response = urlService.saveShortUrl(longUrl, request.getExpiredAt());
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/url/ShortenIt/domain/url/domain/Url.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/domain/Url.java
@@ -13,6 +13,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 
+import java.time.Instant;
+
 @Entity
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
@@ -30,11 +32,26 @@ public class Url extends BaseEntity{
     @Column(nullable = false)
     private String shortUrl;
 
+    @Column(name = "expired_at")
+    private Instant expiredAt;
+
     public static Url create(String longUrl, String shortUrl) {
         return Url.builder()
             .longUrl(longUrl)
             .shortUrl(shortUrl)
             .build();
+    }
+
+    public static Url create(String longUrl, String shortUrl, Instant expiredAt) {
+        return Url.builder()
+            .longUrl(longUrl)
+            .shortUrl(shortUrl)
+            .expiredAt(expiredAt)
+            .build();
+    }
+
+    public boolean isExpired() {
+        return expiredAt != null && Instant.now().isAfter(expiredAt);
     }
 }
 

--- a/src/main/java/com/url/ShortenIt/domain/url/dto/request/LongUrlRequest.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/dto/request/LongUrlRequest.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.time.Instant;
+
 @Getter
 @Setter
 @AllArgsConstructor
@@ -17,4 +19,8 @@ public class LongUrlRequest {
     @Schema(description = "원본 URL", example = "https://www.example.com")
     @JsonProperty("long_url")
     private String longUrl;
+
+    @Schema(description = "만료 시간 (ISO-8601)", example = "2026-12-31T23:59:59Z")
+    @JsonProperty("expired_at")
+    private Instant expiredAt;
 }

--- a/src/main/java/com/url/ShortenIt/domain/url/repository/Urlrepository.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/repository/Urlrepository.java
@@ -1,7 +1,12 @@
 package com.url.ShortenIt.domain.url.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 import com.url.ShortenIt.domain.url.domain.Url;
@@ -12,6 +17,11 @@ public interface Urlrepository extends JpaRepository<Url, Long> {
     Optional<Url> findById(Long id);
 
     Optional<Url> findByLongUrl(String longUrl);
-    Optional<Url> findByShortUrl(String shortUrl); 
-    
+    Optional<Url> findByShortUrl(String shortUrl);
+
+    List<Url> findAllByExpiredAtBeforeAndExpiredAtIsNotNull(Instant now);
+
+    @Modifying
+    @Query("DELETE FROM Url u WHERE u.expiredAt IS NOT NULL AND u.expiredAt < :now")
+    int deleteAllExpiredBefore(@Param("now") Instant now);
 }

--- a/src/main/java/com/url/ShortenIt/domain/url/scheduler/ExpiredUrlCleanupScheduler.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/scheduler/ExpiredUrlCleanupScheduler.java
@@ -1,0 +1,28 @@
+package com.url.ShortenIt.domain.url.scheduler;
+
+import com.url.ShortenIt.domain.url.repository.Urlrepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExpiredUrlCleanupScheduler {
+
+    private final Urlrepository urlrepository;
+
+    @Scheduled(cron = "0 0 * * * *") // 매시간 정각에 실행
+    @Transactional
+    public void cleanupExpiredUrls() {
+        Instant now = Instant.now();
+        int deletedCount = urlrepository.deleteAllExpiredBefore(now);
+        if (deletedCount > 0) {
+            log.info("Expired URL cleanup: {} URLs deleted", deletedCount);
+        }
+    }
+}

--- a/src/main/java/com/url/ShortenIt/domain/url/service/UrlService.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/service/UrlService.java
@@ -4,9 +4,11 @@ import com.url.ShortenIt.domain.url.dto.response.ShortUrlResponse;
 import com.url.ShortenIt.domain.url.dto.response.UrlInfoResponse;
 
 
+import java.time.Instant;
+
 public interface UrlService {
 
-    ShortUrlResponse saveShortUrl(String longUrl);
+    ShortUrlResponse saveShortUrl(String longUrl, Instant expiredAt);
     UrlInfoResponse searchLongUrl(String shortUrl);
     void deleteUrl(String shortUrl);
 }

--- a/src/main/java/com/url/ShortenIt/domain/url/service/UrlServiceIpml.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/service/UrlServiceIpml.java
@@ -16,6 +16,7 @@ import java.util.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
+import java.time.Instant;
 
 @AllArgsConstructor
 @Service
@@ -32,7 +33,7 @@ public class UrlServiceIpml implements UrlService {
 
     @Override
     @Transactional
-    public ShortUrlResponse saveShortUrl(String longUrl) {
+    public ShortUrlResponse saveShortUrl(String longUrl, Instant expiredAt) {
         String normalized = normalizeLongUrl(longUrl);
 
         // 1. 캐시 조회 (Cache-Aside 패턴 적용)
@@ -50,11 +51,11 @@ public class UrlServiceIpml implements UrlService {
             putToCache(CACHE_S2L_PREFIX + shortUrl, normalized);
             return new ShortUrlResponse(shortUrl);
         }else{
-            // 4. 신규 URL 생성 (SnowFlake + Base62
+            // 4. 신규 URL 생성 (SnowFlake + Base62)
             SnowFlake snowFlake = new SnowFlake(1,1);
             Long id = snowFlake.nextId();
             String str = BaseConversion.encode(id);
-            Url urlEntity = Url.create(normalized,str);
+            Url urlEntity = Url.create(normalized, str, expiredAt);
             Urlrepository.save(urlEntity);
             // 캐시에 기록
             putToCache(CACHE_L2S_PREFIX + normalized, str);
@@ -77,6 +78,10 @@ public class UrlServiceIpml implements UrlService {
 
         Optional<Url> url =  Urlrepository.findByShortUrl(shortUrl);
         Url found = url.orElseThrow(() -> new IllegalArgumentException("Short URL not found: " + shortUrl));
+        // 만료된 URL 체크
+        if (found.isExpired()) {
+            throw new IllegalArgumentException("This URL has expired: " + shortUrl);
+        }
         // 캐시에 기록
         putToCache(CACHE_S2L_PREFIX + shortUrl, found.getLongUrl());
         putToCache(CACHE_L2S_PREFIX + found.getLongUrl(), shortUrl);

--- a/src/test/java/com/url/ShortenIt/domain/url/controller/UrlControllerTest.java
+++ b/src/test/java/com/url/ShortenIt/domain/url/controller/UrlControllerTest.java
@@ -65,7 +65,7 @@ class UrlControllerTest {
     void testGetLongUrl_Success() throws Exception {
         // given
         String longUrl = "https://www.google.com";
-        ShortUrlResponse response = urlService.saveShortUrl(longUrl);
+        ShortUrlResponse response = urlService.saveShortUrl(longUrl, null);
         String shortUrl = response.shortUrl();
 
         // when & then
@@ -84,7 +84,7 @@ class UrlControllerTest {
         request.setLongUrl(longUrl);
 
         // 첫 번째 생성
-        ShortUrlResponse firstResponse = urlService.saveShortUrl(longUrl);
+        ShortUrlResponse firstResponse = urlService.saveShortUrl(longUrl, null);
         String firstShortUrl = firstResponse.shortUrl();
 
         // 두 번째 생성 요청


### PR DESCRIPTION
## Summary
- Url 엔티티에 `expiredAt` 필드 추가하여 URL 만료 라이프사이클 구축
- `@EnableScheduling` + `ExpiredUrlCleanupScheduler`로 매시간 만료 URL Bulk Delete
- URL 생성 시 선택적 만료 시간 설정 기능 추가
- 만료된 URL 접근 시 예외 처리

## 변경 사항
- `Url`: `expiredAt` 필드 및 `isExpired()` 메서드 추가
- `LongUrlRequest`: `expired_at` 필드 추가
- `UrlService/UrlServiceIpml`: `saveShortUrl(String, Instant)` 시그니처 변경, 만료 URL 체크
- `ExpiredUrlCleanupScheduler`: cron `0 0 * * * *` (매시간) 배치 삭제
- `Urlrepository`: `deleteAllExpiredBefore` JPQL 쿼리 추가

## Test plan
- [x] 컴파일 성공
- [ ] 만료 시간 설정 후 URL 생성 → 만료 후 리디렉션 시 에러 반환 확인
- [ ] Scheduler 실행 후 만료 URL DB 삭제 확인

Closes #26