### PR TITLE
feat: Nginx 로드 밸런싱을 통한 서버 부하 분산

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,20 @@
 version: '3.8'
 
 services:
-  app:
-    build: .
+  nginx:
+    image: nginx:alpine
     ports:
-      - "8080:8080"
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - app-1
+      - app-2
+
+  app-1:
+    build: .
+    expose:
+      - "8080"
     environment:
       - TZ=Asia/Seoul
       - SPRING_PROFILES_ACTIVE=docker
@@ -13,7 +23,29 @@ services:
       - SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/${POSTGRES_DB}
       - SPRING_DATASOURCE_USERNAME=${POSTGRES_USER}
       - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
-      
+
+      # === 1. Redis 비밀번호를 Spring Boot에 전달 ===
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
+
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  app-2:
+    build: .
+    expose:
+      - "8080"
+    environment:
+      - TZ=Asia/Seoul
+      - SPRING_PROFILES_ACTIVE=docker
+
+      # PostgreSQL 연결 정보
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/${POSTGRES_DB}
+      - SPRING_DATASOURCE_USERNAME=${POSTGRES_USER}
+      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+
       # === 1. Redis 비밀번호를 Spring Boot에 전달 ===
       - REDIS_PASSWORD=${REDIS_PASSWORD}
 
@@ -50,7 +82,7 @@ services:
       retries: 5
 
     environment:
-      - REDIS_PASSWORD=${REDIS_PASSWORD} 
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
     ports:
       - "6379:6379"
     volumes:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,24 @@
+upstream app_servers {
+    least_conn;
+    server app-1:8080;
+    server app-2:8080;
+}
+
+server {
+    listen 80;
+
+    location / {
+        proxy_pass http://app_servers;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 30s;
+    }
+
+    location /actuator/health {
+        proxy_pass http://app_servers;
+        proxy_set_header Host $host;
+    }
+}


### PR DESCRIPTION
## Summary
- Nginx를 로드 밸런서로 도입, Least Connection 방식 트래픽 분산
- 앱 서버를 2개 인스턴스로 Scale-out 구성
- 외부 트래픽은 80 포트(Nginx)를 통해 앱 서버로 라우팅

## 변경 사항
- `nginx/nginx.conf`: upstream 블록(least_conn), 프록시 헤더 설정
- `docker-compose.yml`: nginx 서비스 추가, app → app-1/app-2 분리, ports → expose 변경

## Test plan
- [ ] `docker compose up --build` 후 80 포트로 요청 시 정상 응답 확인
- [ ] 두 인스턴스 간 요청 분산 확인 (로그 비교)
- [ ] 한 인스턴스 중단 시 나머지 인스턴스로 트래픽 전환 확인

Closes #27