### PR TITLE
fix: AI 코드리뷰 피드백 반영

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -20,5 +20,8 @@ server {
     location /actuator/health {
         proxy_pass http://app_servers;
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }

--- a/src/main/java/com/url/ShortenIt/domain/url/domain/Url.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/domain/Url.java
@@ -51,8 +51,10 @@ public class Url extends BaseEntity{
     }
 
     public boolean isExpired() {
-        return expiredAt != null && Instant.now().isAfter(expiredAt);
+        return isExpired(Instant.now());
+    }
+
+    public boolean isExpired(Instant now) {
+        return expiredAt != null && now.isAfter(expiredAt);
     }
 }
-
-

--- a/src/main/java/com/url/ShortenIt/domain/url/repository/Urlrepository.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/repository/Urlrepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 
 import com.url.ShortenIt.domain.url.domain.Url;
@@ -18,8 +17,6 @@ public interface Urlrepository extends JpaRepository<Url, Long> {
 
     Optional<Url> findByLongUrl(String longUrl);
     Optional<Url> findByShortUrl(String shortUrl);
-
-    List<Url> findAllByExpiredAtBeforeAndExpiredAtIsNotNull(Instant now);
 
     @Modifying
     @Query("DELETE FROM Url u WHERE u.expiredAt IS NOT NULL AND u.expiredAt < :now")

--- a/src/main/java/com/url/ShortenIt/domain/url/service/CacheInvalidationPublisher.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/service/CacheInvalidationPublisher.java
@@ -1,13 +1,14 @@
 package com.url.ShortenIt.domain.url.service;
 
+import com.url.ShortenIt.global.config.RedisPubSubConfig;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class CacheInvalidationPublisher {
-
-    private static final String CACHE_INVALIDATION_TOPIC = "cache:invalidation";
 
     @Autowired(required = false)
     private StringRedisTemplate redisTemplate;
@@ -16,8 +17,10 @@ public class CacheInvalidationPublisher {
         if (redisTemplate == null) return;
         try {
             String message = shortUrl + "|" + longUrl;
-            redisTemplate.convertAndSend(CACHE_INVALIDATION_TOPIC, message);
-        } catch (Exception ignored) {
+            redisTemplate.convertAndSend(RedisPubSubConfig.CACHE_INVALIDATION_TOPIC, message);
+        } catch (Exception e) {
+            log.error("Failed to publish cache invalidation message", e);
+            throw new IllegalStateException("Failed to publish cache invalidation message", e);
         }
     }
 }

--- a/src/main/java/com/url/ShortenIt/domain/url/service/CacheInvalidationSubscriber.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/service/CacheInvalidationSubscriber.java
@@ -26,9 +26,14 @@ public class CacheInvalidationSubscriber {
             String shortUrl = parts[0];
             String longUrl = parts[1];
 
+            if (shortUrl.isBlank() || longUrl.isBlank()) {
+                log.warn("Blank shortUrl or longUrl in cache invalidation message: {}", message);
+                return;
+            }
+
             redisTemplate.delete(CACHE_S2L_PREFIX + shortUrl);
             redisTemplate.delete(CACHE_L2S_PREFIX + longUrl);
-            log.info("Cache invalidated for shortUrl={}, longUrl={}", shortUrl, longUrl);
+            log.debug("Cache invalidated for shortUrl={}", shortUrl);
         } catch (Exception e) {
             log.error("Failed to process cache invalidation message", e);
         }

--- a/src/main/java/com/url/ShortenIt/domain/url/service/UrlServiceIpml.java
+++ b/src/main/java/com/url/ShortenIt/domain/url/service/UrlServiceIpml.java
@@ -6,11 +6,13 @@ import com.url.ShortenIt.domain.url.dto.response.UrlInfoResponse;
 import com.url.ShortenIt.domain.url.repository.Urlrepository;
 import com.url.ShortenIt.domain.url.util.BaseConversion;
 import com.url.ShortenIt.domain.url.util.SnowFlake;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.*;
 import java.net.URI;
@@ -18,13 +20,14 @@ import java.net.URISyntaxException;
 import java.time.Duration;
 import java.time.Instant;
 
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Service
 public class UrlServiceIpml implements UrlService {
 
     private final Urlrepository Urlrepository;
     private final BaseConversion BaseConversion;
     private final CacheInvalidationPublisher cacheInvalidationPublisher;
+    private final SnowFlake snowFlake;
 
     @Autowired(required = false)
     private StringRedisTemplate redisTemplate;
@@ -51,21 +54,18 @@ public class UrlServiceIpml implements UrlService {
             putToCache(CACHE_L2S_PREFIX + normalized, shortUrl);
             putToCache(CACHE_S2L_PREFIX + shortUrl, normalized);
             return new ShortUrlResponse(shortUrl);
-        }else{
+        } else {
             // 4. 신규 URL 생성 (SnowFlake + Base62)
-            SnowFlake snowFlake = new SnowFlake(1,1);
             Long id = snowFlake.nextId();
             String str = BaseConversion.encode(id);
             Url urlEntity = Url.create(normalized, str, expiredAt);
             Urlrepository.save(urlEntity);
-            // 캐시에 기록
-            putToCache(CACHE_L2S_PREFIX + normalized, str);
-            putToCache(CACHE_S2L_PREFIX + str, normalized);
+            // 캐시에 기록 (만료시간 기반 TTL)
+            Duration cacheTtl = calculateCacheTtl(expiredAt);
+            putToCache(CACHE_L2S_PREFIX + normalized, str, cacheTtl);
+            putToCache(CACHE_S2L_PREFIX + str, normalized, cacheTtl);
             return new ShortUrlResponse(urlEntity.getShortUrl());
         }
-
- 
-
     }
 
     @Override
@@ -77,15 +77,16 @@ public class UrlServiceIpml implements UrlService {
             return new UrlInfoResponse(longUrl, shortUrl);
         }
 
-        Optional<Url> url =  Urlrepository.findByShortUrl(shortUrl);
+        Optional<Url> url = Urlrepository.findByShortUrl(shortUrl);
         Url found = url.orElseThrow(() -> new IllegalArgumentException("Short URL not found: " + shortUrl));
         // 만료된 URL 체크
         if (found.isExpired()) {
-            throw new IllegalArgumentException("This URL has expired: " + shortUrl);
+            throw new IllegalStateException("This URL has expired: " + shortUrl);
         }
-        // 캐시에 기록
-        putToCache(CACHE_S2L_PREFIX + shortUrl, found.getLongUrl());
-        putToCache(CACHE_L2S_PREFIX + found.getLongUrl(), shortUrl);
+        // 캐시에 기록 (만료시간 기반 TTL)
+        Duration cacheTtl = calculateCacheTtl(found.getExpiredAt());
+        putToCache(CACHE_S2L_PREFIX + shortUrl, found.getLongUrl(), cacheTtl);
+        putToCache(CACHE_L2S_PREFIX + found.getLongUrl(), shortUrl, cacheTtl);
         return new UrlInfoResponse(found.getLongUrl(), found.getShortUrl());
     }
 
@@ -95,8 +96,13 @@ public class UrlServiceIpml implements UrlService {
         Url url = Urlrepository.findByShortUrl(shortUrl).orElseThrow(() -> new IllegalArgumentException("Short URL not found: " + shortUrl));
         String longUrl = url.getLongUrl();
         Urlrepository.delete(url);
-        // Redis Pub/Sub을 통한 캐시 무효화 (모든 인스턴스에 전파)
-        cacheInvalidationPublisher.publishInvalidation(shortUrl, longUrl);
+        // 트랜잭션 커밋 후 캐시 무효화 발행
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                cacheInvalidationPublisher.publishInvalidation(shortUrl, longUrl);
+            }
+        });
     }
 
     private String normalizeLongUrl(String original) {
@@ -117,7 +123,7 @@ public class UrlServiceIpml implements UrlService {
         }
         return trimmed;
     }
-    
+
     private String getFromCache(String key) {
         if (redisTemplate == null) return null;
         try {
@@ -128,11 +134,27 @@ public class UrlServiceIpml implements UrlService {
     }
 
     private void putToCache(String key, String value) {
+        putToCache(key, value, Duration.ofHours(24));
+    }
+
+    private void putToCache(String key, String value, Duration ttl) {
         if (redisTemplate == null) return;
         try {
-            redisTemplate.opsForValue().set(key, value, Duration.ofHours(24));
+            redisTemplate.opsForValue().set(key, value, ttl);
         } catch (Exception ignored) {
         }
+    }
+
+    private Duration calculateCacheTtl(Instant expiredAt) {
+        if (expiredAt == null) {
+            return Duration.ofHours(24);
+        }
+        Duration remaining = Duration.between(Instant.now(), expiredAt);
+        if (remaining.isNegative() || remaining.isZero()) {
+            return Duration.ofSeconds(1);
+        }
+        Duration defaultTtl = Duration.ofHours(24);
+        return remaining.compareTo(defaultTtl) < 0 ? remaining : defaultTtl;
     }
 
     private void deleteFromCache(String key) {
@@ -142,5 +164,4 @@ public class UrlServiceIpml implements UrlService {
         } catch (Exception ignored) {
         }
     }
-        
 }

--- a/src/main/java/com/url/ShortenIt/global/config/RedisPubSubConfig.java
+++ b/src/main/java/com/url/ShortenIt/global/config/RedisPubSubConfig.java
@@ -14,6 +14,7 @@ import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 public class RedisPubSubConfig {
 
     public static final String CACHE_INVALIDATION_TOPIC = "cache:invalidation";
+    public static final String LISTENER_METHOD = "onMessage";
 
     @Bean
     public ChannelTopic cacheInvalidationTopic() {
@@ -22,7 +23,7 @@ public class RedisPubSubConfig {
 
     @Bean
     public MessageListenerAdapter messageListenerAdapter(CacheInvalidationSubscriber subscriber) {
-        return new MessageListenerAdapter(subscriber, "onMessage");
+        return new MessageListenerAdapter(subscriber, LISTENER_METHOD);
     }
 
     @Bean

--- a/src/main/java/com/url/ShortenIt/global/config/SnowFlakeConfig.java
+++ b/src/main/java/com/url/ShortenIt/global/config/SnowFlakeConfig.java
@@ -1,0 +1,13 @@
+package com.url.ShortenIt.global.config;
+
+import com.url.ShortenIt.domain.url.util.SnowFlake;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SnowFlakeConfig {
+    @Bean
+    public SnowFlake snowFlake() {
+        return new SnowFlake(1, 1);
+    }
+}

--- a/src/test/java/com/url/ShortenIt/domain/url/controller/UrlControllerTest.java
+++ b/src/test/java/com/url/ShortenIt/domain/url/controller/UrlControllerTest.java
@@ -5,6 +5,7 @@ import com.url.ShortenIt.domain.url.dto.request.LongUrlRequest;
 import com.url.ShortenIt.domain.url.dto.response.ShortUrlResponse;
 import com.url.ShortenIt.domain.url.repository.Urlrepository;
 import com.url.ShortenIt.domain.url.service.UrlService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +14,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -23,7 +23,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@Transactional
 @ActiveProfiles("test")
 class UrlControllerTest {
 
@@ -38,6 +37,11 @@ class UrlControllerTest {
 
     @Autowired
     private Urlrepository urlRepository;
+
+    @AfterEach
+    void tearDown() {
+        urlRepository.deleteAll();
+    }
 
     @Test
     @DisplayName("URL 단축 생성 테스트 - 성공")
@@ -116,7 +120,7 @@ class UrlControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.short_url").exists());
 
-        // shortUrl 추출 (간단한 문자열 추출 - 실제로는 JSON 파싱 필요)
+        // shortUrl 추출
         String shortUrl = urlRepository.findByLongUrl(longUrl)
                 .orElseThrow()
                 .getShortUrl();

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,19 +1,23 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver
     username: sa
     password:
-  
+
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+
   jpa:
     hibernate:
       ddl-auto: create-drop
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.H2Dialect
     show-sql: true
-  
+
   h2:
     console:
       enabled: true


### PR DESCRIPTION
## Summary
- PR #28, #29, #30에서 받은 AI 코드리뷰 (CodeRabbit, Gemini) 피드백 반영

## Changes

### Redis Pub/Sub (PR #28)
- **[Critical]** 캐시 무효화를 `afterCommit()` 콜백으로 이동 → Stale 캐시 방지
- **[Major]** CacheInvalidationPublisher 예외 로깅 + `IllegalStateException` 재전파
- **[Major]** CacheInvalidationSubscriber 민감 URL 로그 노출 방지 (`debug` 레벨)
- **[Medium]** `CACHE_INVALIDATION_TOPIC` 중복 상수 제거 → `RedisPubSubConfig` 참조
- **[Medium]** 메시지 파싱 후 빈 값 검증 추가
- **[Medium]** `"onMessage"` 문자열 리터럴 → `LISTENER_METHOD` 상수 추출

### Scheduler/만료 (PR #29)
- **[Critical]** SnowFlake 매번 생성 → 싱글톤 Bean 등록 (`SnowFlakeConfig`)
- **[High]** 캐시 TTL이 URL 만료시간 무시 → `calculateCacheTtl()` 만료시간 기반 TTL
- **[Medium]** `isExpired(Instant now)` 파라미터 추가 (테스트 용이성)
- **[Medium]** 미사용 `findAllByExpiredAtBeforeAndExpiredAtIsNotNull` 삭제
- **[Medium]** 만료 URL 예외 `IllegalArgumentException` → `IllegalStateException`

### Nginx (PR #30)
- **[Medium]** `/actuator/health` 프록시 헤더 일관성 수정

Closes #31

## Test plan
- [ ] `./gradlew build -x test` 빌드 성공 확인
- [ ] URL 생성/조회/삭제 시나리오 검증
- [ ] 만료 URL 접근 시 `IllegalStateException` 발생 확인
- [ ] 캐시 무효화가 트랜잭션 커밋 후 발행되는지 확인