### PR TITLE
fix: 데이터 모델 개선 - 인덱스, Soft Delete, 컬럼 길이

### DIFF
--- a/common/src/main/java/com/url/ShortenIt/common/domain/BaseEntity.java
+++ b/common/src/main/java/com/url/ShortenIt/common/domain/BaseEntity.java
@@ -20,4 +20,8 @@ public abstract class BaseEntity {
 
     @Column(name = "deleted_at")
     private Instant deletedAt;
+
+    protected void markDeleted() {
+        this.deletedAt = Instant.now();
+    }
 }

--- a/common/src/main/java/com/url/ShortenIt/common/domain/Url.java
+++ b/common/src/main/java/com/url/ShortenIt/common/domain/Url.java
@@ -2,6 +2,8 @@ package com.url.ShortenIt.common.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,10 +12,17 @@ import lombok.AccessLevel;
 import jakarta.persistence.Id;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.Instant;
 
 @Entity
+@Table(name = "url", indexes = {
+    @Index(name = "idx_url_short_url", columnList = "shortUrl", unique = true),
+    @Index(name = "idx_url_long_url", columnList = "longUrl", unique = true),
+    @Index(name = "idx_url_expired_at", columnList = "expired_at")
+})
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -24,10 +33,10 @@ public class Url extends BaseEntity {
     @Column(name = "url_id")
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true, length = 2048)
     private String longUrl;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String shortUrl;
 
     @Column(name = "expired_at")
@@ -50,5 +59,9 @@ public class Url extends BaseEntity {
 
     public boolean isExpired() {
         return expiredAt != null && Instant.now().isAfter(expiredAt);
+    }
+
+    public void softDelete() {
+        this.markDeleted();
     }
 }

--- a/common/src/main/java/com/url/ShortenIt/common/repository/Urlrepository.java
+++ b/common/src/main/java/com/url/ShortenIt/common/repository/Urlrepository.java
@@ -14,14 +14,12 @@ import com.url.ShortenIt.common.domain.Url;
 @Repository
 public interface Urlrepository extends JpaRepository<Url, Long> {
 
-    Optional<Url> findById(Long id);
-
     Optional<Url> findByLongUrl(String longUrl);
     Optional<Url> findByShortUrl(String shortUrl);
 
     List<Url> findAllByExpiredAtBeforeAndExpiredAtIsNotNull(Instant now);
 
     @Modifying
-    @Query("DELETE FROM Url u WHERE u.expiredAt IS NOT NULL AND u.expiredAt < :now")
-    int deleteAllExpiredBefore(@Param("now") Instant now);
+    @Query("UPDATE Url u SET u.deletedAt = :now WHERE u.expiredAt IS NOT NULL AND u.expiredAt < :now AND u.deletedAt IS NULL")
+    int softDeleteAllExpiredBefore(@Param("now") Instant now);
 }

--- a/redirect-service/src/test/java/com/url/ShortenIt/redirectservice/controller/RedirectControllerTest.java
+++ b/redirect-service/src/test/java/com/url/ShortenIt/redirectservice/controller/RedirectControllerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -22,9 +23,10 @@ class RedirectControllerTest {
 
     @Autowired private MockMvc mockMvc;
     @Autowired private Urlrepository urlRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
 
     @AfterEach
-    void tearDown() { urlRepository.deleteAll(); }
+    void tearDown() { jdbcTemplate.execute("DELETE FROM url"); }
 
     @Test
     @DisplayName("URL 리다이렉트 테스트 - 성공")

--- a/url-service/src/main/java/com/url/ShortenIt/urlservice/scheduler/ExpiredUrlCleanupScheduler.java
+++ b/url-service/src/main/java/com/url/ShortenIt/urlservice/scheduler/ExpiredUrlCleanupScheduler.java
@@ -20,9 +20,9 @@ public class ExpiredUrlCleanupScheduler {
     @Transactional
     public void cleanupExpiredUrls() {
         Instant now = Instant.now();
-        int deletedCount = urlrepository.deleteAllExpiredBefore(now);
+        int deletedCount = urlrepository.softDeleteAllExpiredBefore(now);
         if (deletedCount > 0) {
-            log.info("Expired URL cleanup: {} URLs deleted", deletedCount);
+            log.info("Expired URL cleanup: {} URLs soft-deleted", deletedCount);
         }
     }
 }

--- a/url-service/src/main/java/com/url/ShortenIt/urlservice/service/UrlManagementServiceImpl.java
+++ b/url-service/src/main/java/com/url/ShortenIt/urlservice/service/UrlManagementServiceImpl.java
@@ -68,7 +68,7 @@ public class UrlManagementServiceImpl implements UrlManagementService {
         Url url = urlrepository.findByShortUrl(shortUrl)
                 .orElseThrow(() -> new IllegalArgumentException("Short URL not found: " + shortUrl));
         String longUrl = url.getLongUrl();
-        urlrepository.delete(url);
+        url.softDelete();
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {

--- a/url-service/src/test/java/com/url/ShortenIt/urlservice/controller/UrlManagementControllerTest.java
+++ b/url-service/src/test/java/com/url/ShortenIt/urlservice/controller/UrlManagementControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -29,9 +30,10 @@ class UrlManagementControllerTest {
     @Autowired private ObjectMapper objectMapper;
     @Autowired private UrlManagementService urlManagementService;
     @Autowired private Urlrepository urlRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
 
     @AfterEach
-    void tearDown() { urlRepository.deleteAll(); }
+    void tearDown() { jdbcTemplate.execute("DELETE FROM url"); }
 
     @Test
     @DisplayName("URL 단축 생성 테스트 - 성공")


### PR DESCRIPTION
## Summary
- `Url` 엔티티에 DB 인덱스 및 유니크 제약조건 추가 (`shortUrl`, `longUrl`, `expiredAt`)
- `@SQLRestriction` 기반 Soft Delete 구현으로 데이터 복구 가능성 확보
- `longUrl` 컬럼 길이를 VARCHAR(255) → VARCHAR(2048)로 확장
- 불필요한 `findById()` 중복 선언 제거

## Changes
| 파일 | 변경 내용 |
|------|-----------|
| `Url.java` | `@Table` 인덱스, `@SQLRestriction`, 컬럼 길이, `softDelete()` 메서드 |
| `BaseEntity.java` | `markDeleted()` 메서드 추가 |
| `Urlrepository.java` | `softDeleteAllExpiredBefore()`, 불필요한 `findById` 제거 |
| `UrlManagementServiceImpl.java` | `deleteUrl()` soft delete 적용 |
| `ExpiredUrlCleanupScheduler.java` | soft delete 방식으로 변경 |
| 테스트 파일 2개 | `tearDown`을 `JdbcTemplate`으로 변경 (SQLRestriction 우회) |

## 기대 효과
- `findByShortUrl` 쿼리: Full Table Scan → Index Scan (O(n) → O(log n))
- DB 레벨 유니크 제약으로 중복 URL 생성 방지
- Soft Delete로 실수로 삭제된 데이터 복구 가능

## Test plan
- [x] url-service 전체 테스트 통과
- [x] redirect-service 전체 테스트 통과

closes #34