### PR TITLE
refactor: 캐시 로직 공통화 및 Repository 네이밍 수정

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -7,6 +7,7 @@ jar { enabled = true }
 
 dependencies {
 	api 'org.springframework.boot:spring-boot-starter-data-jpa'
+	api 'org.springframework.boot:spring-boot-starter-data-redis'
 	api 'org.springframework.boot:spring-boot-starter-validation'
 
 	// Swagger annotations

--- a/common/src/main/java/com/url/ShortenIt/common/repository/UrlRepository.java
+++ b/common/src/main/java/com/url/ShortenIt/common/repository/UrlRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import com.url.ShortenIt.common.domain.Url;
 
 @Repository
-public interface Urlrepository extends JpaRepository<Url, Long> {
+public interface UrlRepository extends JpaRepository<Url, Long> {
 
     Optional<Url> findByLongUrl(String longUrl);
     Optional<Url> findByShortUrl(String shortUrl);

--- a/common/src/main/java/com/url/ShortenIt/common/service/CacheService.java
+++ b/common/src/main/java/com/url/ShortenIt/common/service/CacheService.java
@@ -1,0 +1,61 @@
+package com.url.ShortenIt.common.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+
+@Slf4j
+@Service
+public class CacheService {
+
+    public static final String CACHE_L2S_PREFIX = "L2S:";
+    public static final String CACHE_S2L_PREFIX = "S2L:";
+
+    private static final Duration DEFAULT_TTL = Duration.ofHours(24);
+
+    @Autowired(required = false)
+    private StringRedisTemplate redisTemplate;
+
+    public String get(String key) {
+        if (redisTemplate == null) return null;
+        try {
+            return redisTemplate.opsForValue().get(key);
+        } catch (Exception e) {
+            log.warn("Redis GET failed for key={}: {}", key, e.getMessage());
+            return null;
+        }
+    }
+
+    public void put(String key, String value) {
+        put(key, value, DEFAULT_TTL);
+    }
+
+    public void put(String key, String value, Duration ttl) {
+        if (redisTemplate == null) return;
+        try {
+            redisTemplate.opsForValue().set(key, value, ttl);
+        } catch (Exception e) {
+            log.warn("Redis SET failed for key={}: {}", key, e.getMessage());
+        }
+    }
+
+    public void delete(String key) {
+        if (redisTemplate == null) return;
+        try {
+            redisTemplate.delete(key);
+        } catch (Exception e) {
+            log.warn("Redis DELETE failed for key={}: {}", key, e.getMessage());
+        }
+    }
+
+    public Duration calculateCacheTtl(Instant expiredAt) {
+        if (expiredAt == null) return DEFAULT_TTL;
+        Duration remaining = Duration.between(Instant.now(), expiredAt);
+        if (remaining.isNegative() || remaining.isZero()) return Duration.ofSeconds(1);
+        return remaining.compareTo(DEFAULT_TTL) < 0 ? remaining : DEFAULT_TTL;
+    }
+}

--- a/docs/INTERVIEW_NOTES.md
+++ b/docs/INTERVIEW_NOTES.md
@@ -1,0 +1,150 @@
+# Shortly - 이력서 & 면접 정리
+
+## 프로젝트 한줄 소개
+> 대규모 트래픽을 고려한 URL 단축 서비스를 MSA로 설계·구현하고, Redis 캐싱과 Pub/Sub을 활용한 다중 인스턴스 간 데이터 일관성을 보장하는 시스템
+
+---
+
+## 1. Redis Pub/Sub 기반 캐시 무효화
+
+### 이력서 표현
+> **문제**: URL 삭제 시 다중화된 서버 인스턴스 간 로컬 캐시 불일치로 리디렉션 오류 발생
+> **해결**: URL 상태 변경 시 Redis Pub/Sub 토픽으로 메시지를 Publish하고, 모든 인스턴스가 Subscribe하여 즉시 캐시 무효화
+> **성과**: 만료 URL 접근 시 리디렉션 오류율 0% 달성, 데이터 일관성 보장
+
+### 면접 대비 Q&A
+
+**Q: 왜 Redis Pub/Sub을 선택했나요?**
+- 이미 캐시용으로 Redis를 사용 중이라 추가 인프라 비용 없음
+- Fire-and-forget 방식으로 캐시 무효화에 적합 (메시지 유실 시 TTL로 자연 만료)
+- Kafka 등 메시지 큐 대비 지연시간이 낮아 실시간 무효화에 유리
+
+**Q: Pub/Sub 메시지 유실 시 어떻게 대응하나요?**
+- Redis 캐시에 TTL(24시간)을 설정하여 메시지 유실 시에도 자연 만료
+- Pub/Sub은 at-most-once 보장 → 캐시 무효화는 결과적 일관성(Eventual Consistency)으로 충분
+- 데이터 정합성이 중요한 경우 Redis Streams나 Kafka 도입 고려
+
+**Q: TransactionSynchronization을 왜 사용했나요?**
+- DB 트랜잭션 커밋 전에 캐시를 무효화하면, 롤백 시 캐시만 삭제되는 불일치 발생
+- `afterCommit()`에서 Publish하여 DB 커밋 성공 후에만 캐시 무효화 보장
+
+**Q: Cache-Aside 패턴을 설명해주세요.**
+- 읽기: 캐시 조회 → 미스 시 DB 조회 → 캐시에 저장
+- 쓰기: DB 저장 → 캐시 갱신 또는 무효화
+- 장점: 캐시 장애 시 DB로 fallback 가능, 구현이 단순
+- 단점: 캐시 미스 시 지연시간 증가 (Cold Start)
+
+---
+
+## 2. Spring Scheduler 기반 만료 데이터 배치 삭제
+
+### 이력서 표현
+> **문제**: 만료된 URL 데이터가 DB에 누적되어 스토리지 낭비 및 쿼리 성능 저하
+> **해결**: Spring Scheduler를 활용하여 만료 URL을 주기적으로 Bulk Delete하는 배치 작업 구현
+> **성과**: URL 만료/삭제 라이프사이클 100% 구축, 불필요한 데이터 적재 방지
+
+### 면접 대비 Q&A
+
+**Q: 왜 Bulk Delete를 사용했나요?**
+- 개별 DELETE 대비 DB I/O 횟수 감소 → 트랜잭션 오버헤드 최소화
+- JPQL `DELETE` 쿼리로 영속성 컨텍스트를 거치지 않아 메모리 효율적
+- 대량 데이터 삭제 시 인덱스 재구성 비용도 한 번만 발생
+
+**Q: 스케줄러가 여러 인스턴스에서 동시 실행되면?**
+- 현재: JPQL DELETE가 멱등성(Idempotent) → 중복 실행해도 문제 없음
+- 개선 방안: ShedLock 라이브러리로 분산 락 적용, 단일 인스턴스만 실행하도록 제어
+- 또는 @SchedulerLock으로 Redis/DB 기반 분산 락 설정
+
+**Q: 매시간 실행인데, 더 세밀한 만료 처리가 필요하면?**
+- Redis TTL을 활용하여 캐시 레벨에서 즉시 만료 처리 (현재 구현됨)
+- DB 조회 시 `isExpired()` 체크로 스케줄러 실행 전에도 만료 URL 접근 차단
+- 실시간 필요 시: Redis Keyspace Notifications로 만료 이벤트 수신
+
+**Q: `expiredAt` 필드 인덱스는?**
+- WHERE 조건에 자주 사용되므로 복합 인덱스 `(expired_at, url_id)` 추가 권장
+- NULL이 많은 컬럼이므로 Partial Index 고려 (`WHERE expired_at IS NOT NULL`)
+
+---
+
+## 3. Nginx 로드 밸런싱 & API Gateway
+
+### 이력서 표현
+> **문제**: 단일 서버 운영으로 트래픽 급증 시 SPOF(Single Point of Failure) 발생
+> **해결**: Nginx를 API Gateway로 도입, Least Connection 방식 로드 밸런싱 및 경로 기반 서비스 라우팅 구현
+> **성과**: 서버 부하 분산으로 트래픽 처리 능력 향상 및 SPOF 완화
+
+### 면접 대비 Q&A
+
+**Q: Least Connection 방식을 선택한 이유는?**
+- Round Robin: 모든 서버에 균등 분배 → 처리 시간이 다른 요청에 불리
+- Least Connection: 현재 연결 수가 가장 적은 서버에 분배 → URL 리디렉션처럼 응답시간 편차가 큰 서비스에 적합
+- IP Hash: 세션 유지 필요 시 → Stateless 서비스이므로 불필요
+
+**Q: MSA에서 Nginx의 역할은?**
+- **API Gateway**: 클라이언트 단일 진입점, 내부 서비스 라우팅
+- **로드 밸런서**: 동일 서비스 다중 인스턴스 간 부하 분산
+- **리버스 프록시**: 내부 서비스 포트 은닉, 보안 헤더 추가
+- Spring Cloud Gateway 대비: 더 가볍고 성능 우수, L7 수준 라우팅 가능
+
+**Q: Nginx가 SPOF가 되지 않나요?**
+- 맞음. Nginx 자체의 HA를 위해 Keepalived + VIP 구성 필요
+- 클라우드 환경에서는 AWS ALB/NLB 등 관리형 로드밸런서 사용
+- Docker Swarm/K8s에서는 내장 Service Discovery와 로드밸런싱 활용
+
+---
+
+## 4. MSA 전환
+
+### 이력서 표현
+> **설계**: 모놀리식 서비스를 쓰기 최적화(url-service)와 읽기 최적화(redirect-service)로 분리하여 독립 배포·확장 가능한 MSA 구현
+> **성과**: 서비스별 독립 스케일링 가능, Redis Pub/Sub 기반 비동기 서비스 간 통신으로 느슨한 결합 달성
+
+### 면접 대비 Q&A
+
+**Q: 왜 MSA로 전환했나요?**
+- URL 리디렉션(읽기)은 트래픽의 90% 이상, URL 생성(쓰기)은 10% 미만
+- 읽기/쓰기 서비스를 분리하여 독립 스케일링 → redirect-service만 3~5배 확장 가능
+- 서비스별 독립 배포로 장애 격리 및 배포 주기 단축
+
+**Q: 서비스를 어떤 기준으로 분리했나요?**
+- **CQRS 패턴** 기반: Command(쓰기) vs Query(읽기) 분리
+- url-service: 쓰기 책임 (생성, 삭제, 스케줄러) → 데이터 무결성 중심
+- redirect-service: 읽기 책임 (리디렉션, 프리뷰) → 응답 속도 중심
+- common 모듈: 공유 엔티티/DTO로 코드 중복 제거
+
+**Q: 공유 DB를 사용하면 MSA의 장점이 줄어들지 않나요?**
+- 맞음. 현재는 공유 DB(PostgreSQL)로 전환 비용 최소화
+- 향후 개선: url-service는 Write DB, redirect-service는 Read Replica 사용
+- 또는 redirect-service는 Redis만 의존하고, Cache Miss 시 url-service API 호출로 완전 분리
+
+**Q: 서비스 간 통신은 어떻게 하나요?**
+- **동기 통신**: 현재 없음 (공유 DB로 간접 통신)
+- **비동기 통신**: Redis Pub/Sub으로 캐시 무효화 이벤트 전파
+- 향후: gRPC로 서비스 간 직접 통신, 또는 이벤트 소싱 도입 가능
+
+**Q: Docker Compose의 한계와 대안은?**
+- 한계: 단일 호스트, 오토스케일링 불가, 셀프 힐링 없음
+- 대안: Kubernetes (자동 스케일링, 서비스 디스커버리, 롤링 업데이트)
+- 현 단계에서는 Docker Compose로 충분, K8s는 트래픽 증가 시 전환
+
+---
+
+## 5. 기술적 깊이 (공통)
+
+### SnowFlake ID 생성
+- Twitter에서 개발한 분산 ID 생성 알고리즘
+- 64비트: 타임스탬프(41) + 데이터센터(5) + 머신(5) + 시퀀스(12)
+- Auto Increment 대비 장점: 분산 환경에서 충돌 없이 ID 생성, ID로 생성 시간 추정 가능
+- Base62 인코딩으로 짧은 URL 문자열 생성
+
+### Redis 캐시 전략
+- **L2S (Long to Short)**: 동일 URL 중복 생성 방지
+- **S2L (Short to Long)**: 리디렉션 시 DB 조회 최소화
+- **TTL**: 기본 24시간, 만료 시간이 설정된 URL은 남은 시간 기반 동적 TTL
+- **캐시 무효화**: Pub/Sub + TTL 이중 전략
+
+### 테스트 전략
+- `@SpringBootTest` + `@AutoConfigureMockMvc`: 통합 테스트
+- Redis 자동설정 제외: 테스트 환경에서 외부 의존성 격리
+- `@AfterEach` cleanup: 테스트 간 데이터 격리
+- H2 인메모리 DB: PostgreSQL 호환 모드로 로컬 테스트

--- a/redirect-service/src/main/java/com/url/ShortenIt/redirectservice/RedirectServiceApplication.java
+++ b/redirect-service/src/main/java/com/url/ShortenIt/redirectservice/RedirectServiceApplication.java
@@ -3,11 +3,13 @@ package com.url.ShortenIt.redirectservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 @EntityScan(basePackages = "com.url.ShortenIt.common.domain")
 @EnableJpaRepositories(basePackages = "com.url.ShortenIt.common.repository")
+@ComponentScan(basePackages = {"com.url.ShortenIt.redirectservice", "com.url.ShortenIt.common"})
 public class RedirectServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(RedirectServiceApplication.class, args);

--- a/redirect-service/src/main/java/com/url/ShortenIt/redirectservice/service/CacheInvalidationSubscriber.java
+++ b/redirect-service/src/main/java/com/url/ShortenIt/redirectservice/service/CacheInvalidationSubscriber.java
@@ -1,22 +1,21 @@
 package com.url.ShortenIt.redirectservice.service;
 
+import com.url.ShortenIt.common.service.CacheService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
+
+import static com.url.ShortenIt.common.service.CacheService.CACHE_L2S_PREFIX;
+import static com.url.ShortenIt.common.service.CacheService.CACHE_S2L_PREFIX;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class CacheInvalidationSubscriber {
 
-    private static final String CACHE_L2S_PREFIX = "L2S:";
-    private static final String CACHE_S2L_PREFIX = "S2L:";
-
-    @Autowired(required = false)
-    private StringRedisTemplate redisTemplate;
+    private final CacheService cacheService;
 
     public void onMessage(String message, String channel) {
-        if (redisTemplate == null) return;
         try {
             String[] parts = message.split("\\|", 2);
             if (parts.length != 2) {
@@ -26,8 +25,8 @@ public class CacheInvalidationSubscriber {
             String shortUrl = parts[0];
             String longUrl = parts[1];
 
-            redisTemplate.delete(CACHE_S2L_PREFIX + shortUrl);
-            redisTemplate.delete(CACHE_L2S_PREFIX + longUrl);
+            cacheService.delete(CACHE_S2L_PREFIX + shortUrl);
+            cacheService.delete(CACHE_L2S_PREFIX + longUrl);
             log.info("Cache invalidated for shortUrl={}, longUrl={}", shortUrl, longUrl);
         } catch (Exception e) {
             log.error("Failed to process cache invalidation message", e);

--- a/redirect-service/src/main/java/com/url/ShortenIt/redirectservice/service/RedirectServiceImpl.java
+++ b/redirect-service/src/main/java/com/url/ShortenIt/redirectservice/service/RedirectServiceImpl.java
@@ -2,68 +2,41 @@ package com.url.ShortenIt.redirectservice.service;
 
 import com.url.ShortenIt.common.domain.Url;
 import com.url.ShortenIt.common.dto.response.UrlInfoResponse;
-import com.url.ShortenIt.common.repository.Urlrepository;
+import com.url.ShortenIt.common.repository.UrlRepository;
+import com.url.ShortenIt.common.service.CacheService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Optional;
+
+import static com.url.ShortenIt.common.service.CacheService.CACHE_L2S_PREFIX;
+import static com.url.ShortenIt.common.service.CacheService.CACHE_S2L_PREFIX;
 
 @RequiredArgsConstructor
 @Service
 public class RedirectServiceImpl implements RedirectService {
 
-    private final Urlrepository urlrepository;
-
-    @Autowired(required = false)
-    private StringRedisTemplate redisTemplate;
-
-    private static final String CACHE_L2S_PREFIX = "L2S:";
-    private static final String CACHE_S2L_PREFIX = "S2L:";
+    private final UrlRepository urlRepository;
+    private final CacheService cacheService;
 
     @Override
     @Transactional(readOnly = true)
     public UrlInfoResponse searchLongUrl(String shortUrl) {
-        // 1) 캐시에서 조회
-        String longUrl = getFromCache(CACHE_S2L_PREFIX + shortUrl);
+        String longUrl = cacheService.get(CACHE_S2L_PREFIX + shortUrl);
         if (longUrl != null) {
             return new UrlInfoResponse(longUrl, shortUrl);
         }
 
-        Optional<Url> url = urlrepository.findByShortUrl(shortUrl);
+        Optional<Url> url = urlRepository.findByShortUrl(shortUrl);
         Url found = url.orElseThrow(() -> new IllegalArgumentException("Short URL not found: " + shortUrl));
-        // 만료된 URL 체크
         if (found.isExpired()) {
             throw new IllegalStateException("This URL has expired: " + shortUrl);
         }
-        // 캐시에 기록 (만료시간 기반 TTL)
-        Duration cacheTtl = calculateCacheTtl(found.getExpiredAt());
-        putToCache(CACHE_S2L_PREFIX + shortUrl, found.getLongUrl(), cacheTtl);
-        putToCache(CACHE_L2S_PREFIX + found.getLongUrl(), shortUrl, cacheTtl);
+        Duration cacheTtl = cacheService.calculateCacheTtl(found.getExpiredAt());
+        cacheService.put(CACHE_S2L_PREFIX + shortUrl, found.getLongUrl(), cacheTtl);
+        cacheService.put(CACHE_L2S_PREFIX + found.getLongUrl(), shortUrl, cacheTtl);
         return new UrlInfoResponse(found.getLongUrl(), found.getShortUrl());
-    }
-
-    private String getFromCache(String key) {
-        if (redisTemplate == null) return null;
-        try { return redisTemplate.opsForValue().get(key); }
-        catch (Exception ignored) { return null; }
-    }
-
-    private void putToCache(String key, String value, Duration ttl) {
-        if (redisTemplate == null) return;
-        try { redisTemplate.opsForValue().set(key, value, ttl); }
-        catch (Exception ignored) {}
-    }
-
-    private Duration calculateCacheTtl(Instant expiredAt) {
-        if (expiredAt == null) return Duration.ofHours(24);
-        Duration remaining = Duration.between(Instant.now(), expiredAt);
-        if (remaining.isNegative() || remaining.isZero()) return Duration.ofSeconds(1);
-        Duration defaultTtl = Duration.ofHours(24);
-        return remaining.compareTo(defaultTtl) < 0 ? remaining : defaultTtl;
     }
 }

--- a/redirect-service/src/test/java/com/url/ShortenIt/redirectservice/controller/RedirectControllerTest.java
+++ b/redirect-service/src/test/java/com/url/ShortenIt/redirectservice/controller/RedirectControllerTest.java
@@ -1,7 +1,7 @@
 package com.url.ShortenIt.redirectservice.controller;
 
 import com.url.ShortenIt.common.domain.Url;
-import com.url.ShortenIt.common.repository.Urlrepository;
+import com.url.ShortenIt.common.repository.UrlRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class RedirectControllerTest {
 
     @Autowired private MockMvc mockMvc;
-    @Autowired private Urlrepository urlRepository;
+    @Autowired private UrlRepository urlRepository;
     @Autowired private JdbcTemplate jdbcTemplate;
 
     @AfterEach

--- a/url-service/src/main/java/com/url/ShortenIt/urlservice/UrlServiceApplication.java
+++ b/url-service/src/main/java/com/url/ShortenIt/urlservice/UrlServiceApplication.java
@@ -11,7 +11,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication
 @EntityScan(basePackages = "com.url.ShortenIt.common.domain")
 @EnableJpaRepositories(basePackages = "com.url.ShortenIt.common.repository")
-@ComponentScan(basePackages = {"com.url.ShortenIt.urlservice", "com.url.ShortenIt.common.util"})
+@ComponentScan(basePackages = {"com.url.ShortenIt.urlservice", "com.url.ShortenIt.common"})
 public class UrlServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(UrlServiceApplication.class, args);

--- a/url-service/src/main/java/com/url/ShortenIt/urlservice/scheduler/ExpiredUrlCleanupScheduler.java
+++ b/url-service/src/main/java/com/url/ShortenIt/urlservice/scheduler/ExpiredUrlCleanupScheduler.java
@@ -1,6 +1,6 @@
 package com.url.ShortenIt.urlservice.scheduler;
 
-import com.url.ShortenIt.common.repository.Urlrepository;
+import com.url.ShortenIt.common.repository.UrlRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -14,7 +14,7 @@ import java.time.Instant;
 @RequiredArgsConstructor
 public class ExpiredUrlCleanupScheduler {
 
-    private final Urlrepository urlrepository;
+    private final UrlRepository urlrepository;
 
     @Scheduled(cron = "0 0 * * * *")
     @Transactional

--- a/url-service/src/main/java/com/url/ShortenIt/urlservice/service/UrlManagementServiceImpl.java
+++ b/url-service/src/main/java/com/url/ShortenIt/urlservice/service/UrlManagementServiceImpl.java
@@ -2,12 +2,11 @@ package com.url.ShortenIt.urlservice.service;
 
 import com.url.ShortenIt.common.domain.Url;
 import com.url.ShortenIt.common.dto.response.ShortUrlResponse;
-import com.url.ShortenIt.common.repository.Urlrepository;
+import com.url.ShortenIt.common.repository.UrlRepository;
+import com.url.ShortenIt.common.service.CacheService;
 import com.url.ShortenIt.common.util.BaseConversion;
 import com.url.ShortenIt.common.util.SnowFlake;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -19,45 +18,43 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 
+import static com.url.ShortenIt.common.service.CacheService.CACHE_L2S_PREFIX;
+import static com.url.ShortenIt.common.service.CacheService.CACHE_S2L_PREFIX;
+
 @RequiredArgsConstructor
 @Service
 public class UrlManagementServiceImpl implements UrlManagementService {
 
-    private final Urlrepository urlrepository;
+    private final UrlRepository urlRepository;
     private final BaseConversion baseConversion;
     private final CacheInvalidationPublisher cacheInvalidationPublisher;
     private final SnowFlake snowFlake;
-
-    @Autowired(required = false)
-    private StringRedisTemplate redisTemplate;
-
-    private static final String CACHE_L2S_PREFIX = "L2S:";
-    private static final String CACHE_S2L_PREFIX = "S2L:";
+    private final CacheService cacheService;
 
     @Override
     @Transactional
     public ShortUrlResponse saveShortUrl(String longUrl, Instant expiredAt) {
         String normalized = normalizeLongUrl(longUrl);
 
-        String cachedShort = getFromCache(CACHE_L2S_PREFIX + normalized);
+        String cachedShort = cacheService.get(CACHE_L2S_PREFIX + normalized);
         if (cachedShort != null) {
             return new ShortUrlResponse(cachedShort);
         }
 
-        Optional<Url> url = urlrepository.findByLongUrl(normalized);
+        Optional<Url> url = urlRepository.findByLongUrl(normalized);
         if (url.isPresent()) {
             String shortUrl = url.get().getShortUrl();
-            putToCache(CACHE_L2S_PREFIX + normalized, shortUrl);
-            putToCache(CACHE_S2L_PREFIX + shortUrl, normalized);
+            cacheService.put(CACHE_L2S_PREFIX + normalized, shortUrl);
+            cacheService.put(CACHE_S2L_PREFIX + shortUrl, normalized);
             return new ShortUrlResponse(shortUrl);
         } else {
             Long id = snowFlake.nextId();
             String str = baseConversion.encode(id);
             Url urlEntity = Url.create(normalized, str, expiredAt);
-            urlrepository.save(urlEntity);
-            Duration cacheTtl = calculateCacheTtl(expiredAt);
-            putToCache(CACHE_L2S_PREFIX + normalized, str, cacheTtl);
-            putToCache(CACHE_S2L_PREFIX + str, normalized, cacheTtl);
+            urlRepository.save(urlEntity);
+            Duration cacheTtl = cacheService.calculateCacheTtl(expiredAt);
+            cacheService.put(CACHE_L2S_PREFIX + normalized, str, cacheTtl);
+            cacheService.put(CACHE_S2L_PREFIX + str, normalized, cacheTtl);
             return new ShortUrlResponse(urlEntity.getShortUrl());
         }
     }
@@ -65,7 +62,7 @@ public class UrlManagementServiceImpl implements UrlManagementService {
     @Override
     @Transactional
     public void deleteUrl(String shortUrl) {
-        Url url = urlrepository.findByShortUrl(shortUrl)
+        Url url = urlRepository.findByShortUrl(shortUrl)
                 .orElseThrow(() -> new IllegalArgumentException("Short URL not found: " + shortUrl));
         String longUrl = url.getLongUrl();
         url.softDelete();
@@ -94,29 +91,5 @@ public class UrlManagementServiceImpl implements UrlManagementService {
             throw new IllegalArgumentException("Invalid URL: " + original);
         }
         return trimmed;
-    }
-
-    private String getFromCache(String key) {
-        if (redisTemplate == null) return null;
-        try { return redisTemplate.opsForValue().get(key); }
-        catch (Exception ignored) { return null; }
-    }
-
-    private void putToCache(String key, String value) {
-        putToCache(key, value, Duration.ofHours(24));
-    }
-
-    private void putToCache(String key, String value, Duration ttl) {
-        if (redisTemplate == null) return;
-        try { redisTemplate.opsForValue().set(key, value, ttl); }
-        catch (Exception ignored) {}
-    }
-
-    private Duration calculateCacheTtl(Instant expiredAt) {
-        if (expiredAt == null) return Duration.ofHours(24);
-        Duration remaining = Duration.between(Instant.now(), expiredAt);
-        if (remaining.isNegative() || remaining.isZero()) return Duration.ofSeconds(1);
-        Duration defaultTtl = Duration.ofHours(24);
-        return remaining.compareTo(defaultTtl) < 0 ? remaining : defaultTtl;
     }
 }

--- a/url-service/src/test/java/com/url/ShortenIt/urlservice/controller/UrlManagementControllerTest.java
+++ b/url-service/src/test/java/com/url/ShortenIt/urlservice/controller/UrlManagementControllerTest.java
@@ -3,7 +3,7 @@ package com.url.ShortenIt.urlservice.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.url.ShortenIt.common.dto.request.LongUrlRequest;
 import com.url.ShortenIt.common.dto.response.ShortUrlResponse;
-import com.url.ShortenIt.common.repository.Urlrepository;
+import com.url.ShortenIt.common.repository.UrlRepository;
 import com.url.ShortenIt.urlservice.service.UrlManagementService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -29,7 +29,7 @@ class UrlManagementControllerTest {
     @Autowired private MockMvc mockMvc;
     @Autowired private ObjectMapper objectMapper;
     @Autowired private UrlManagementService urlManagementService;
-    @Autowired private Urlrepository urlRepository;
+    @Autowired private UrlRepository urlRepository;
     @Autowired private JdbcTemplate jdbcTemplate;
 
     @AfterEach


### PR DESCRIPTION
## Summary
- common 모듈에 `CacheService` 클래스 추출 (3개 파일의 중복 캐시 코드 통합)
- `Urlrepository` → `UrlRepository` Java 네이밍 컨벤션 수정
- silent `catch (Exception ignored) {}` → `log.warn`으로 변경

## Changes
| 파일 | 변경 내용 |
|------|-----------|
| `CacheService.java` (신규) | get/put/delete/calculateCacheTtl 공통 캐시 로직 |
| `UrlManagementServiceImpl.java` | CacheService 주입, 중복 캐시 코드 제거 |
| `RedirectServiceImpl.java` | CacheService 주입, 중복 캐시 코드 제거 |
| `CacheInvalidationSubscriber.java` | CacheService 기반으로 리팩토링 |
| `Urlrepository → UrlRepository` | 클래스명 네이밍 컨벤션 수정 |
| `UrlServiceApplication.java` | ComponentScan 범위 common 전체로 확장 |
| `RedirectServiceApplication.java` | ComponentScan 추가 |

## 기대 효과
- 캐시 로직 변경 시 1곳(CacheService)만 수정 → 유지보수성 향상
- Redis 장애 시 log.warn으로 추적 가능 (기존: silent catch)
- 코드 중복 약 60줄 제거

## Test plan
- [x] url-service 전체 테스트 통과
- [x] redirect-service 전체 테스트 통과

closes #36