### PR TITLE
fix: 에러 처리 개선 - 커스텀 예외, 에러 메시지 보호, 서비스 로깅

### DIFF
--- a/common/src/main/java/com/url/ShortenIt/common/exception/UrlExpiredException.java
+++ b/common/src/main/java/com/url/ShortenIt/common/exception/UrlExpiredException.java
@@ -1,0 +1,7 @@
+package com.url.ShortenIt.common.exception;
+
+public class UrlExpiredException extends RuntimeException {
+    public UrlExpiredException(String shortUrl) {
+        super("This URL has expired: " + shortUrl);
+    }
+}

--- a/common/src/main/java/com/url/ShortenIt/common/exception/UrlNotFoundException.java
+++ b/common/src/main/java/com/url/ShortenIt/common/exception/UrlNotFoundException.java
@@ -1,0 +1,7 @@
+package com.url.ShortenIt.common.exception;
+
+public class UrlNotFoundException extends RuntimeException {
+    public UrlNotFoundException(String shortUrl) {
+        super("Short URL not found: " + shortUrl);
+    }
+}

--- a/redirect-service/src/main/java/com/url/ShortenIt/redirectservice/config/GlobalExceptionHandler.java
+++ b/redirect-service/src/main/java/com/url/ShortenIt/redirectservice/config/GlobalExceptionHandler.java
@@ -1,13 +1,29 @@
 package com.url.ShortenIt.redirectservice.config;
 
+import com.url.ShortenIt.common.exception.UrlExpiredException;
+import com.url.ShortenIt.common.exception.UrlNotFoundException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.Map;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(UrlNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleUrlNotFoundException(UrlNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(Map.of("error", "not_found", "message", ex.getMessage()));
+    }
+
+    @ExceptionHandler(UrlExpiredException.class)
+    public ResponseEntity<Map<String, String>> handleUrlExpiredException(UrlExpiredException ex) {
+        return ResponseEntity.status(HttpStatus.GONE)
+                .body(Map.of("error", "url_expired", "message", ex.getMessage()));
+    }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException ex) {
@@ -15,15 +31,10 @@ public class GlobalExceptionHandler {
                 .body(Map.of("error", "invalid_request", "message", ex.getMessage()));
     }
 
-    @ExceptionHandler(IllegalStateException.class)
-    public ResponseEntity<Map<String, String>> handleIllegalStateException(IllegalStateException ex) {
-        return ResponseEntity.status(HttpStatus.GONE)
-                .body(Map.of("error", "url_expired", "message", ex.getMessage()));
-    }
-
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, String>> handleException(Exception ex) {
+        log.error("Unexpected error occurred", ex);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(Map.of("error", "internal_error", "message", ex.getMessage()));
+                .body(Map.of("error", "internal_error", "message", "서버 내부 오류가 발생했습니다."));
     }
 }

--- a/redirect-service/src/main/java/com/url/ShortenIt/redirectservice/service/RedirectServiceImpl.java
+++ b/redirect-service/src/main/java/com/url/ShortenIt/redirectservice/service/RedirectServiceImpl.java
@@ -2,9 +2,12 @@ package com.url.ShortenIt.redirectservice.service;
 
 import com.url.ShortenIt.common.domain.Url;
 import com.url.ShortenIt.common.dto.response.UrlInfoResponse;
+import com.url.ShortenIt.common.exception.UrlExpiredException;
+import com.url.ShortenIt.common.exception.UrlNotFoundException;
 import com.url.ShortenIt.common.repository.UrlRepository;
 import com.url.ShortenIt.common.service.CacheService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +17,7 @@ import java.util.Optional;
 import static com.url.ShortenIt.common.service.CacheService.CACHE_L2S_PREFIX;
 import static com.url.ShortenIt.common.service.CacheService.CACHE_S2L_PREFIX;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class RedirectServiceImpl implements RedirectService {
@@ -30,10 +34,11 @@ public class RedirectServiceImpl implements RedirectService {
         }
 
         Optional<Url> url = urlRepository.findByShortUrl(shortUrl);
-        Url found = url.orElseThrow(() -> new IllegalArgumentException("Short URL not found: " + shortUrl));
+        Url found = url.orElseThrow(() -> new UrlNotFoundException(shortUrl));
         if (found.isExpired()) {
-            throw new IllegalStateException("This URL has expired: " + shortUrl);
+            throw new UrlExpiredException(shortUrl);
         }
+        log.info("Redirect: {} -> {}", shortUrl, found.getLongUrl());
         Duration cacheTtl = cacheService.calculateCacheTtl(found.getExpiredAt());
         cacheService.put(CACHE_S2L_PREFIX + shortUrl, found.getLongUrl(), cacheTtl);
         cacheService.put(CACHE_L2S_PREFIX + found.getLongUrl(), shortUrl, cacheTtl);

--- a/redirect-service/src/test/java/com/url/ShortenIt/redirectservice/controller/RedirectControllerTest.java
+++ b/redirect-service/src/test/java/com/url/ShortenIt/redirectservice/controller/RedirectControllerTest.java
@@ -58,6 +58,6 @@ class RedirectControllerTest {
     void testRedirect_NotFound() throws Exception {
         mockMvc.perform(get("/api/v1/url/{shortUrl}", "nonexistent"))
                 .andDo(print())
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isNotFound());
     }
 }

--- a/url-service/src/main/java/com/url/ShortenIt/urlservice/config/GlobalExceptionHandler.java
+++ b/url-service/src/main/java/com/url/ShortenIt/urlservice/config/GlobalExceptionHandler.java
@@ -1,13 +1,22 @@
 package com.url.ShortenIt.urlservice.config;
 
+import com.url.ShortenIt.common.exception.UrlNotFoundException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.Map;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(UrlNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleUrlNotFoundException(UrlNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(Map.of("error", "not_found", "message", ex.getMessage()));
+    }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException ex) {
@@ -17,7 +26,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, String>> handleException(Exception ex) {
+        log.error("Unexpected error occurred", ex);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(Map.of("error", "internal_error", "message", ex.getMessage()));
+                .body(Map.of("error", "internal_error", "message", "서버 내부 오류가 발생했습니다."));
     }
 }

--- a/url-service/src/main/java/com/url/ShortenIt/urlservice/service/UrlManagementServiceImpl.java
+++ b/url-service/src/main/java/com/url/ShortenIt/urlservice/service/UrlManagementServiceImpl.java
@@ -2,11 +2,13 @@ package com.url.ShortenIt.urlservice.service;
 
 import com.url.ShortenIt.common.domain.Url;
 import com.url.ShortenIt.common.dto.response.ShortUrlResponse;
+import com.url.ShortenIt.common.exception.UrlNotFoundException;
 import com.url.ShortenIt.common.repository.UrlRepository;
 import com.url.ShortenIt.common.service.CacheService;
 import com.url.ShortenIt.common.util.BaseConversion;
 import com.url.ShortenIt.common.util.SnowFlake;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -21,6 +23,7 @@ import java.util.Optional;
 import static com.url.ShortenIt.common.service.CacheService.CACHE_L2S_PREFIX;
 import static com.url.ShortenIt.common.service.CacheService.CACHE_S2L_PREFIX;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class UrlManagementServiceImpl implements UrlManagementService {
@@ -46,6 +49,7 @@ public class UrlManagementServiceImpl implements UrlManagementService {
             String shortUrl = url.get().getShortUrl();
             cacheService.put(CACHE_L2S_PREFIX + normalized, shortUrl);
             cacheService.put(CACHE_S2L_PREFIX + shortUrl, normalized);
+            log.info("Existing short URL returned: {} -> {}", shortUrl, normalized);
             return new ShortUrlResponse(shortUrl);
         } else {
             Long id = snowFlake.nextId();
@@ -55,6 +59,7 @@ public class UrlManagementServiceImpl implements UrlManagementService {
             Duration cacheTtl = cacheService.calculateCacheTtl(expiredAt);
             cacheService.put(CACHE_L2S_PREFIX + normalized, str, cacheTtl);
             cacheService.put(CACHE_S2L_PREFIX + str, normalized, cacheTtl);
+            log.info("New short URL created: {} -> {}", str, normalized);
             return new ShortUrlResponse(urlEntity.getShortUrl());
         }
     }
@@ -63,9 +68,10 @@ public class UrlManagementServiceImpl implements UrlManagementService {
     @Transactional
     public void deleteUrl(String shortUrl) {
         Url url = urlRepository.findByShortUrl(shortUrl)
-                .orElseThrow(() -> new IllegalArgumentException("Short URL not found: " + shortUrl));
+                .orElseThrow(() -> new UrlNotFoundException(shortUrl));
         String longUrl = url.getLongUrl();
         url.softDelete();
+        log.info("URL deleted: {} -> {}", shortUrl, longUrl);
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {


### PR DESCRIPTION
## Summary
- `UrlNotFoundException`, `UrlExpiredException` 커스텀 예외 도입
- `GlobalExceptionHandler`의 catch-all에서 내부 에러 메시지 클라이언트 노출 제거
- 서비스 레이어에 `@Slf4j` 로깅 추가 (URL 생성/삭제/리다이렉트)

## Changes
| 파일 | 변경 내용 |
|------|-----------|
| `UrlNotFoundException.java` (신규) | URL 미존재 커스텀 예외 |
| `UrlExpiredException.java` (신규) | URL 만료 커스텀 예외 |
| `UrlManagementServiceImpl.java` | 커스텀 예외 적용 + 로깅 추가 |
| `RedirectServiceImpl.java` | 커스텀 예외 적용 + 로깅 추가 |
| `GlobalExceptionHandler.java` (양쪽) | 커스텀 예외 핸들러 추가, catch-all 메시지 보호 |
| `RedirectControllerTest.java` | NotFound 응답 404로 변경 |

## Before / After
| 항목 | Before | After |
|------|--------|-------|
| URL 미존재 응답 | 400 Bad Request | 404 Not Found |
| 서버 에러 메시지 | `ex.getMessage()` 노출 | 일반 메시지 + 서버 로그 |
| 예외 구분 | `IllegalArgumentException` 공용 | 비즈니스별 커스텀 예외 |
| 서비스 로깅 | 없음 | URL 생성/삭제/리다이렉트 기록 |

## Test plan
- [x] url-service 전체 테스트 통과
- [x] redirect-service 전체 테스트 통과

closes #38