### PR TITLE
fix: 입력값 검증(@Valid) 적용 및 REST 상태코드 개선

### DIFF
--- a/common/src/main/java/com/url/ShortenIt/common/dto/request/LongUrlRequest.java
+++ b/common/src/main/java/com/url/ShortenIt/common/dto/request/LongUrlRequest.java
@@ -1,6 +1,8 @@
 package com.url.ShortenIt.common.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +18,8 @@ import java.time.Instant;
 @Schema(description = "URL 단축 요청 DTO")
 public class LongUrlRequest {
 
+    @NotBlank(message = "long_url 값이 비어 있습니다.")
+    @Size(max = 2048, message = "URL은 2048자를 초과할 수 없습니다.")
     @Schema(description = "원본 URL", example = "https://www.example.com")
     @JsonProperty("long_url")
     private String longUrl;

--- a/url-service/src/main/java/com/url/ShortenIt/urlservice/config/GlobalExceptionHandler.java
+++ b/url-service/src/main/java/com/url/ShortenIt/urlservice/config/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.url.ShortenIt.common.exception.UrlNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.Map;
@@ -16,6 +17,16 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, String>> handleUrlNotFoundException(UrlNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(Map.of("error", "not_found", "message", ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationException(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getDefaultMessage())
+                .findFirst()
+                .orElse("입력값이 올바르지 않습니다.");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("error", "validation_error", "message", message));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/url-service/src/main/java/com/url/ShortenIt/urlservice/controller/UrlManagementController.java
+++ b/url-service/src/main/java/com/url/ShortenIt/urlservice/controller/UrlManagementController.java
@@ -3,7 +3,9 @@ package com.url.ShortenIt.urlservice.controller;
 import com.url.ShortenIt.common.dto.request.LongUrlRequest;
 import com.url.ShortenIt.common.dto.response.ShortUrlResponse;
 import com.url.ShortenIt.urlservice.service.UrlManagementService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,13 +22,9 @@ public class UrlManagementController {
 
     @PostMapping("/shorten")
     @Operation(summary = "URL 단축", description = "URL을 단축합니다.")
-    public ResponseEntity<ShortUrlResponse> createShortUrl(@RequestBody LongUrlRequest request) {
-        String longUrl = request.getLongUrl();
-        if (longUrl == null || longUrl.isBlank()) {
-            throw new IllegalArgumentException("long_url 값이 비어 있습니다.");
-        }
-        ShortUrlResponse response = urlManagementService.saveShortUrl(longUrl, request.getExpiredAt());
-        return ResponseEntity.ok(response);
+    public ResponseEntity<ShortUrlResponse> createShortUrl(@Valid @RequestBody LongUrlRequest request) {
+        ShortUrlResponse response = urlManagementService.saveShortUrl(request.getLongUrl(), request.getExpiredAt());
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @DeleteMapping("/{shortUrl}")

--- a/url-service/src/test/java/com/url/ShortenIt/urlservice/controller/UrlManagementControllerTest.java
+++ b/url-service/src/test/java/com/url/ShortenIt/urlservice/controller/UrlManagementControllerTest.java
@@ -46,7 +46,7 @@ class UrlManagementControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.short_url").exists())
                 .andExpect(jsonPath("$.short_url").isString());
 
@@ -66,7 +66,7 @@ class UrlManagementControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.short_url").value(first.shortUrl()));
     }
 


### PR DESCRIPTION
## Summary
- `LongUrlRequest` DTO에 Bean Validation 어노테이션 적용 (`@NotBlank`, `@Size`)
- Controller에서 수동 null 체크 제거, `@Valid`로 대체
- POST `/shorten` 응답 코드를 REST 컨벤션에 맞게 201 Created로 변경

## Changes
| 파일 | 변경 내용 |
|------|-----------|
| `LongUrlRequest.java` | `@NotBlank`, `@Size(max=2048)` 추가 |
| `UrlManagementController.java` | `@Valid` 적용, 수동 검증 제거, 201 Created |
| `GlobalExceptionHandler.java` | `MethodArgumentNotValidException` 핸들러 추가 |
| `UrlManagementControllerTest.java` | 기대 상태코드 200 → 201 |

## Before / After
| 항목 | Before | After |
|------|--------|-------|
| 입력값 검증 | Controller에서 수동 null 체크 | DTO `@Valid`로 자동 검증 |
| URL 길이 제한 | 없음 (무제한) | 2048자 제한 |
| 생성 응답 코드 | 200 OK | 201 Created |
| 검증 에러 응답 | IllegalArgumentException | validation_error + 필드별 메시지 |

## Test plan
- [x] url-service 전체 테스트 통과
- [x] redirect-service 전체 테스트 통과

closes #40