### PR TITLE
fix: SnowFlake ID 설정 외부화 및 스케줄러 분산 락 적용

### DIFF
--- a/common/src/main/java/com/url/ShortenIt/common/util/SnowFlake.java
+++ b/common/src/main/java/com/url/ShortenIt/common/util/SnowFlake.java
@@ -1,5 +1,6 @@
 package com.url.ShortenIt.common.util;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -23,11 +24,9 @@ public class SnowFlake {
     private long sequence = 0L;
     private long lastTimestamp = -1L;
 
-    public SnowFlake() {
-        this(1, 1);
-    }
-
-    public SnowFlake(long datacenterId, long machineId) {
+    public SnowFlake(
+            @Value("${snowflake.datacenter-id:1}") long datacenterId,
+            @Value("${snowflake.machine-id:1}") long machineId) {
         if (datacenterId > MAX_DATACENTER_NUM || datacenterId < 0) {
             throw new IllegalArgumentException("Datacenter ID can't be greater than " + MAX_DATACENTER_NUM + " or less than 0");
         }

--- a/url-service/src/main/java/com/url/ShortenIt/urlservice/scheduler/ExpiredUrlCleanupScheduler.java
+++ b/url-service/src/main/java/com/url/ShortenIt/urlservice/scheduler/ExpiredUrlCleanupScheduler.java
@@ -3,10 +3,13 @@ package com.url.ShortenIt.urlservice.scheduler;
 import com.url.ShortenIt.common.repository.UrlRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.Instant;
 
 @Slf4j
@@ -14,15 +17,50 @@ import java.time.Instant;
 @RequiredArgsConstructor
 public class ExpiredUrlCleanupScheduler {
 
-    private final UrlRepository urlrepository;
+    private static final String LOCK_KEY = "lock:expired-url-cleanup";
+    private static final Duration LOCK_TTL = Duration.ofMinutes(5);
+
+    private final UrlRepository urlRepository;
+
+    @Autowired(required = false)
+    private StringRedisTemplate redisTemplate;
 
     @Scheduled(cron = "0 0 * * * *")
     @Transactional
     public void cleanupExpiredUrls() {
-        Instant now = Instant.now();
-        int deletedCount = urlrepository.softDeleteAllExpiredBefore(now);
-        if (deletedCount > 0) {
-            log.info("Expired URL cleanup: {} URLs soft-deleted", deletedCount);
+        if (!tryLock()) {
+            log.debug("Another instance is running expired URL cleanup. Skipping.");
+            return;
+        }
+        try {
+            Instant now = Instant.now();
+            int deletedCount = urlRepository.softDeleteAllExpiredBefore(now);
+            if (deletedCount > 0) {
+                log.info("Expired URL cleanup: {} URLs soft-deleted", deletedCount);
+            }
+        } finally {
+            releaseLock();
+        }
+    }
+
+    private boolean tryLock() {
+        if (redisTemplate == null) return true;
+        try {
+            Boolean acquired = redisTemplate.opsForValue()
+                    .setIfAbsent(LOCK_KEY, "locked", LOCK_TTL);
+            return Boolean.TRUE.equals(acquired);
+        } catch (Exception e) {
+            log.warn("Failed to acquire distributed lock: {}", e.getMessage());
+            return true;
+        }
+    }
+
+    private void releaseLock() {
+        if (redisTemplate == null) return;
+        try {
+            redisTemplate.delete(LOCK_KEY);
+        } catch (Exception e) {
+            log.warn("Failed to release distributed lock: {}", e.getMessage());
         }
     }
 }

--- a/url-service/src/main/resources/application.yml
+++ b/url-service/src/main/resources/application.yml
@@ -27,6 +27,10 @@ spring:
 server:
   port: 8081
 
+snowflake:
+  datacenter-id: 1
+  machine-id: 1
+
 springdoc:
   api-docs:
     path: /v3/api-docs


### PR DESCRIPTION
## Summary
- SnowFlake의 datacenterId/machineId를 application.yml에서 설정 가능하게 외부화
- ExpiredUrlCleanupScheduler에 Redis 기반 분산 락 적용

## Changes
| 파일 | 변경 내용 |
|------|-----------|
| `SnowFlake.java` | 하드코딩 제거, `@Value`로 설정 주입 (기본값 1) |
| `ExpiredUrlCleanupScheduler.java` | Redis `setIfAbsent` 기반 분산 락 추가 |
| `application.yml` | `snowflake.datacenter-id`, `snowflake.machine-id` 설정 추가 |

## Before / After
| 항목 | Before | After |
|------|--------|-------|
| SnowFlake 설정 | 하드코딩 (1, 1) | yml에서 설정 가능 |
| 다중 인스턴스 스케줄러 | 모두 동시 실행 | 하나만 실행 (분산 락) |
| Redis 없는 환경 | - | fallback으로 정상 동작 |

## Test plan
- [x] url-service 전체 테스트 통과
- [x] redirect-service 전체 테스트 통과

closes #42