### PR TITLE
fix: Docker 최적화 - .dockerignore, 레이어 캐싱, non-root 사용자

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.gitignore
+.idea
+.vscode
+.claude
+.omc
+*.md
+docs/
+build/
+*/build/
+.gradle
+*/src/test/
+k6/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,11 @@ services:
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
-      - url-service
-      - redirect-service
+      url-service:
+        condition: service_healthy
+      redirect-service:
+        condition: service_healthy
+    restart: unless-stopped
 
   url-service:
     build:
@@ -24,11 +27,18 @@ services:
       - SPRING_DATASOURCE_USERNAME=${POSTGRES_USER}
       - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
       - REDIS_PASSWORD=${REDIS_PASSWORD}
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8081/actuator/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     depends_on:
       db:
         condition: service_healthy
       redis:
         condition: service_healthy
+    restart: unless-stopped
 
   redirect-service:
     build:
@@ -43,11 +53,18 @@ services:
       - SPRING_DATASOURCE_USERNAME=${POSTGRES_USER}
       - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
       - REDIS_PASSWORD=${REDIS_PASSWORD}
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8082/actuator/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     depends_on:
       db:
         condition: service_healthy
       redis:
         condition: service_healthy
+    restart: unless-stopped
 
   db:
     image: postgres:16-alpine
@@ -62,9 +79,10 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - TZ=Asia/Seoul
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - db_data:/var/lib/postgresql/data
+    restart: unless-stopped
 
   redis:
     image: redis:7-alpine
@@ -77,9 +95,10 @@ services:
     environment:
       - REDIS_PASSWORD=${REDIS_PASSWORD}
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis_data:/data
+    restart: unless-stopped
 
 volumes:
   db_data:

--- a/redirect-service/Dockerfile
+++ b/redirect-service/Dockerfile
@@ -1,15 +1,24 @@
 FROM eclipse-temurin:17-jdk-alpine AS build
 WORKDIR /app
-COPY ../gradlew .
-COPY ../gradle gradle
-COPY ../build.gradle .
-COPY ../settings.gradle .
-COPY ../common common
-COPY ../redirect-service redirect-service
-RUN chmod +x gradlew && ./gradlew :redirect-service:bootJar --no-daemon
+
+# Gradle 래퍼 및 빌드 설정 복사 (의존성 캐싱 레이어)
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle .
+COPY settings.gradle .
+COPY common/build.gradle common/build.gradle
+COPY redirect-service/build.gradle redirect-service/build.gradle
+RUN chmod +x gradlew && ./gradlew dependencies --no-daemon || true
+
+# 소스 코드 복사 및 빌드 (코드 변경 시에만 재실행)
+COPY common common
+COPY redirect-service redirect-service
+RUN ./gradlew :redirect-service:bootJar --no-daemon
 
 FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 COPY --from=build /app/redirect-service/build/libs/*.jar app.jar
+USER appuser
 EXPOSE 8082
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/url-service/Dockerfile
+++ b/url-service/Dockerfile
@@ -1,15 +1,24 @@
 FROM eclipse-temurin:17-jdk-alpine AS build
 WORKDIR /app
-COPY ../gradlew .
-COPY ../gradle gradle
-COPY ../build.gradle .
-COPY ../settings.gradle .
-COPY ../common common
-COPY ../url-service url-service
-RUN chmod +x gradlew && ./gradlew :url-service:bootJar --no-daemon
+
+# Gradle 래퍼 및 빌드 설정 복사 (의존성 캐싱 레이어)
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle .
+COPY settings.gradle .
+COPY common/build.gradle common/build.gradle
+COPY url-service/build.gradle url-service/build.gradle
+RUN chmod +x gradlew && ./gradlew dependencies --no-daemon || true
+
+# 소스 코드 복사 및 빌드 (코드 변경 시에만 재실행)
+COPY common common
+COPY url-service url-service
+RUN ./gradlew :url-service:bootJar --no-daemon
 
 FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 COPY --from=build /app/url-service/build/libs/*.jar app.jar
+USER appuser
 EXPOSE 8081
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## Summary
- `.dockerignore` 추가로 빌드 컨텍스트 축소
- Dockerfile 레이어 캐싱 최적화 (의존성/소스 분리)
- non-root 사용자로 컨테이너 실행
- docker-compose 헬스체크, restart 정책, 포트 바인딩 개선

## Changes
| 파일 | 변경 내용 |
|------|-----------|
| `.dockerignore` (신규) | .git, build/, .idea 등 제외 |
| `url-service/Dockerfile` | 레이어 캐싱 분리 + non-root USER |
| `redirect-service/Dockerfile` | 레이어 캐싱 분리 + non-root USER |
| `docker-compose.yml` | 헬스체크, restart, 127.0.0.1 포트 바인딩 |

## Before / After
| 항목 | Before | After |
|------|--------|-------|
| 빌드 컨텍스트 | .git 포함 전체 | 필요 파일만 |
| 코드 변경 시 빌드 | 의존성 전체 재다운로드 | 캐시된 레이어 활용 |
| 컨테이너 권한 | root | appuser (non-root) |
| DB/Redis 외부 접근 | 0.0.0.0 (전체) | 127.0.0.1 (로컬만) |
| 서비스 장애 시 | 수동 재시작 | 자동 재시작 |

## Test plan
- [x] url-service 전체 테스트 통과
- [x] redirect-service 전체 테스트 통과

closes #44